### PR TITLE
Fix(FE): 페이지네이션 위치 항상 아래에 위치하도록 수정

### DIFF
--- a/frontend/src/pages/CustomerPage.jsx
+++ b/frontend/src/pages/CustomerPage.jsx
@@ -41,6 +41,10 @@ const MessageH2 = styled.h2`
   font-weight: 500;
 `;
 
+const CustomerListDiv = styled.div`
+  min-height: calc(54.67px * 10);
+`;
+
 const Pagination = styled.p`
   display: flex;
   gap: 10px;
@@ -168,11 +172,13 @@ const CustomerPage = () => {
         <CustomerTitle
           title={customerData.customer_tracking_records ? Object.keys(customerData.customer_tracking_records[0]) : []}
         />
-        {customerData.customer_tracking_records.map((customer) => {
-          return (
-            <CustomerList key={customer.customer_id} customer={customer} onClick={() => handleModalOpen(customer)} />
-          );
-        })}
+        <CustomerListDiv>
+          {customerData.customer_tracking_records.map((customer) => {
+            return (
+              <CustomerList key={customer.customer_id} customer={customer} onClick={() => handleModalOpen(customer)} />
+            );
+          })}
+        </CustomerListDiv>
         <Pagination>
           <ButtonPage onClick={() => setPage((p) => Math.max(1, p - 1))}>{`<`}</ButtonPage>
           {Array.from({ length: customerData?.pagination?.total_pages || 1 }, (_, index) => index + 1).map((num) => (


### PR DESCRIPTION
### 📝 상세 내용

고객별 추적 기록 페이지의 페이지네이션 위치를 항상 10개 아래에 위치하도록 수정하였습니다. 


### #️⃣ 이슈 번호

- #19 

### 🔗 참고 자료



### 📷 스크린샷(선택)